### PR TITLE
Fix unused variables for clean compilation

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -52,8 +52,8 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ..._props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ..._props }) => <ChevronRight className="h-4 w-4" />,
+        IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+        IconRight: () => <ChevronRight className="h-4 w-4" />,
       }}
       {...props}
     />

--- a/src/components/video-compressor/ProgressTracker.tsx
+++ b/src/components/video-compressor/ProgressTracker.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -147,10 +146,6 @@ export function ProgressTracker({
           const isCompleted = job.status === 'completed';
           const isError = job.status === 'error';
           const isWaiting = job.status === 'waiting';
-
-          const compressionRatio = job.compressedSize 
-            ? ((job.originalSize - job.compressedSize) / job.originalSize) * 100
-            : 0;
 
 
 

--- a/src/components/video-compressor/VideoCompressorSidebar.tsx
+++ b/src/components/video-compressor/VideoCompressorSidebar.tsx
@@ -1,4 +1,4 @@
-import { FaPlay, FaHistory, FaQuestionCircle, FaInfoCircle, FaCog, FaTools, FaWrench } from 'react-icons/fa';
+import { FaPlay, FaHistory, FaQuestionCircle, FaInfoCircle, FaCog, FaWrench } from 'react-icons/fa';
 import { NavLink } from "react-router-dom";
 import React from 'react';
 

--- a/src/pages/VideoRepair.tsx
+++ b/src/pages/VideoRepair.tsx
@@ -16,8 +16,7 @@ import {
   Clock, 
   Download,
   RotateCcw,
-  FileVideo,
-  Zap
+  FileVideo
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 
@@ -58,7 +57,7 @@ function VideoRepairContent() {
     });
   }, [toast]);
 
-  const analyzeVideoFile = useCallback(async (file: File): Promise<RepairJob['issues']> => {
+  const analyzeVideoFile = useCallback(async (): Promise<RepairJob['issues']> => {
     // Simulate video analysis
     await new Promise(resolve => setTimeout(resolve, 500)); // Faster analysis
     
@@ -84,7 +83,7 @@ function VideoRepairContent() {
     if (!job) return;
 
     // Analyze the video file
-    const issues = await analyzeVideoFile(job.file);
+    const issues = await analyzeVideoFile();
     
     setRepairJobs(prev => prev.map(j => 
       j.id === jobId 


### PR DESCRIPTION
## Summary
- drop unused props from Calendar icons
- remove unused React imports and compression ratio logic
- clean up unused icon import in sidebar
- fix unused parameters in VideoRepair

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.app.json`


------
https://chatgpt.com/codex/tasks/task_e_688358f0f3cc8330863ad42872f62115