### PR TITLE
Fix URL cleanup in VideoPreview

### DIFF
--- a/src/components/video-compressor/VideoPreview.tsx
+++ b/src/components/video-compressor/VideoPreview.tsx
@@ -45,18 +45,18 @@ export function VideoPreview({
   // Create URLs only once when component mounts or when files change
   React.useEffect(() => {
     const newOriginalUrl = URL.createObjectURL(originalFile);
-    setOriginalUrl(newOriginalUrl);
+    const newCompressedUrl = compressedBlob
+      ? URL.createObjectURL(compressedBlob)
+      : '';
 
-    if (compressedBlob) {
-      const newCompressedUrl = URL.createObjectURL(compressedBlob);
-      setCompressedUrl(newCompressedUrl);
-    }
+    setOriginalUrl(newOriginalUrl);
+    setCompressedUrl(newCompressedUrl);
 
     // Cleanup URLs when component unmounts or when files change
     return () => {
       URL.revokeObjectURL(newOriginalUrl);
-      if (compressedBlob) {
-        URL.revokeObjectURL(compressedUrl);
+      if (newCompressedUrl) {
+        URL.revokeObjectURL(newCompressedUrl);
       }
     };
   }, [originalFile, compressedBlob]);


### PR DESCRIPTION
## Summary
- generate fresh URLs for original and compressed videos inside the effect
- always store the generated URLs and revoke the correct ones on cleanup

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68838caa56bc83308a3776bcfaf8fcdd